### PR TITLE
Various enhancements as described in #1

### DIFF
--- a/aio_mpv_jsonipc/MPV.py
+++ b/aio_mpv_jsonipc/MPV.py
@@ -27,6 +27,7 @@ class MPV:
         If not it will start a new MPV instance according to the mpv_path argument and connect to it. Optionally you can specify a path or URL
         of a media file to play.
         """
+        self.properties = set()
         self.loop = get_event_loop()
         self.media = media
         self.mpv_args = mpv_args
@@ -160,6 +161,12 @@ class MPV:
                 break
             except FileNotFoundError:
                 await sleep(0.1)
+
+        self.properties = set(
+            p.replace("-", "_")
+            for p in await self.command("get_property", "property-list")
+        )
+
         self.loop.create_task(self._wait_destroy())
         
 

--- a/aio_mpv_jsonipc/MPV.py
+++ b/aio_mpv_jsonipc/MPV.py
@@ -197,7 +197,7 @@ class MPV:
     async def wait_complete(self):
         """
         Coroutine. Wait for the player to exit. Works when the MPV
-        instance is managed by the library. 
+        instance is managed by the library.
         """
         await self.process.wait()
 

--- a/aio_mpv_jsonipc/MPV.py
+++ b/aio_mpv_jsonipc/MPV.py
@@ -69,26 +69,17 @@ class MPV:
         self.socket = "/tmp/mpv-socket.sock"
 
     async def _process_events(self):
+
         while True:
-            counter = 0
-            while True:
-                try:
-                    data = await self.reader.readline()
-                    data = loads(data.decode("utf-8"))
-                    break
-                except ValueError:
-                    counter += 1
-                    continue
-                finally:
-                    if counter >= 10:
-                        await self.stop()
-            if "request_id" in data and data["request_id"] in self.command_responses:
-                self.command_responses[data["request_id"]].set_response(data)
+            data = await self.reader.readline()
+            json_data = loads(data)
+            logger.debug(json_data)
+            if "request_id" in json_data and json_data["request_id"] in self.command_responses:
+                self.command_responses[json_data["request_id"]].set_response(json_data)
             else:
                 await self.callback_queue.put(data)
                 if self.wait_queue:
                     await self.wait_queue.put(data)
-            await sleep(0.1)
 
     async def _callback_dispatcher(self):
         while True:

--- a/aio_mpv_jsonipc/MPV.py
+++ b/aio_mpv_jsonipc/MPV.py
@@ -20,6 +20,11 @@ class ResponseEvent:
         await self.event.wait()
         return self.response
 
+class MPVError(Exception):
+    """An error originating from MPV or due to a problem with MPV."""
+    def __init__(self, *args, **kwargs):
+        super(MPVError, self).__init__(*args, **kwargs)
+
 class MPV:
     def __init__(self, media="", socket=None, mpv_path="/usr/bin/mpv", mpv_args=["--no-audio-display"]):
         """
@@ -123,9 +128,11 @@ class MPV:
             return response
 
     async def command(self, *args):
+        logger.debug(f"command: {args}")
         result = await self.send(args)
         if result.get("error") != "success":
-            logger.warn("mpv command returned error: %s" %(result.get("error")))
+            raise MPVError("mpv command returned error: %s" %(result.get("error")))
+
         return result.get("data")
 
     def listen_for(self, event, func):

--- a/aio_mpv_jsonipc/MPV.py
+++ b/aio_mpv_jsonipc/MPV.py
@@ -118,6 +118,12 @@ class MPV:
             del self.command_responses[self.rid]
             return response
 
+    async def command(self, *args):
+        result = await self.send(args)
+        if result.get("error") != "success":
+            logger.warn("mpv command returned error: %s" %(result.get("error")))
+        return result.get("data")
+
     def listen_for(self, event, func):
         """
         Decorator. This will add a coroutine to be used as a callback for the event specified in the event argument

--- a/aio_mpv_jsonipc/MPV.py
+++ b/aio_mpv_jsonipc/MPV.py
@@ -1,3 +1,5 @@
+import logging
+logger = logging.getLogger(__name__)
 from asyncio import get_event_loop, open_unix_connection, create_subprocess_exec, Queue, Event, sleep, Lock
 from asyncio.subprocess import DEVNULL
 from inspect import iscoroutine


### PR DESCRIPTION
This PR includes the following changes:

* Add property observers via `bind_property_observer`
* Add key bindings via `bind_key_press`
* Add `command()` method as a wrapper around `send()` that handles errors and takes varargs instead of a list
* Removes unnecessary (in my testing) sleep from `_process_events`
* Add logging module (mostly for debugging, but could be used in future to allow apps to collect / react to MPV logs)
* A small number of stylistic changes
